### PR TITLE
restructure dockerfile/install.sh to better re-use the cache on rebuilds

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,6 +3,43 @@
 FROM phusion/baseimage:0.9.16
 MAINTAINER Carlos Hernandez <carlos@techbyte.ca>
 
+
+#########################################
+##    REPOSITORIES AND DEPENDENCIES    ##
+#########################################
+# these are done first because they are unlikely to change.
+# this helps the docker layers work for you on future rebuilds
+
+# install wget so we can get setu the repos
+RUN apt-get update -qq && apt-get install -qy --force-yes wget && apt-get clean -y
+
+
+# Repositories
+RUN wget -qO - http://download.opensuse.org/repositories/home:emby/xUbuntu_14.04/Release.key | apt-key add - && \
+    echo 'deb http://download.opensuse.org/repositories/home:/emby/xUbuntu_14.04/ /' >> /etc/apt/sources.list.d/emby.list && \
+    echo 'deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted' > /etc/apt/sources.list && \
+    echo 'deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse restricted' >> /etc/apt/sources.list && \
+    add-apt-repository ppa:mc3man/trusty-media
+
+# Use mirrors
+# sed -i -e "s#http://[^\s]*archive.ubuntu[^\s]* #mirror://mirrors.ubuntu.com/mirrors.txt #g" /etc/apt/sources.list
+
+# Install Dependencies
+RUN apt-get update -qq && apt-get clean -y
+RUN apt-get install -qy --force-yes mono-runtime \
+                                mediainfo \
+                                libsqlite3-dev \
+                                libc6-dev \
+                                ffmpeg \
+                                imagemagick-6.q8 \
+                                libmagickwand-6.q8-2 \
+                                libmagickcore-6.q8-2 \
+                                sudo \
+                                emby-server && \
+    apt-get clean -y
+
+
+
 #########################################
 ##        ENVIRONMENTAL CONFIG         ##
 #########################################

--- a/Docker/install.sh
+++ b/Docker/install.sh
@@ -105,40 +105,8 @@ EOT
 chmod -R +x /etc/service/ /etc/my_init.d/
 
 #########################################
-##    REPOSITORIES AND DEPENDENCIES    ##
-#########################################
-# Install repos
-apt-get update -qq
-apt-get install -qy --force-yes wget
-
-# Repositories
-wget -qO - http://download.opensuse.org/repositories/home:emby/xUbuntu_14.04/Release.key | apt-key add -
-echo 'deb http://download.opensuse.org/repositories/home:/emby/xUbuntu_14.04/ /' >> /etc/apt/sources.list.d/emby.list
-echo 'deb http://us.archive.ubuntu.com/ubuntu/ trusty main universe multiverse restricted' > /etc/apt/sources.list
-echo 'deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main universe multiverse restricted' >> /etc/apt/sources.list
-add-apt-repository ppa:mc3man/trusty-media
-
-# Use mirrors
-# sed -i -e "s#http://[^\s]*archive.ubuntu[^\s]* #mirror://mirrors.ubuntu.com/mirrors.txt #g" /etc/apt/sources.list
-
-# Install Dependencies
-apt-get update -qq
-apt-get install -qy --force-yes mono-runtime \
-                                mediainfo \
-                                wget \
-                                libsqlite3-dev \
-                                libc6-dev \
-                                ffmpeg \
-                                imagemagick-6.q8 \
-                                libmagickwand-6.q8-2 \
-                                libmagickcore-6.q8-2 \
-				sudo \
-                                emby-server 
-
-#########################################
 ##                 CLEANUP             ##
 #########################################
 
 # Clean APT install files
-apt-get clean -y
 rm -rf /var/lib/apt/lists/* /var/cache/* /var/tmp/*


### PR DESCRIPTION
Running the "update pieces of the OS and install prereqs" and "install the current level of my product" in the same command (`install.sh` in the dockerfile makes it painful to update to new levels of the product because there's not a layer than includes all the prereqs.

Splitting https://github.com/MediaBrowser/Emby.Build/blob/master/Docker/Dockerfile#L19 into different steps in the Dockerfile will help the layers work for you.
