### PR TITLE
fix minor json formatting issue in Rockstor rock-on plugin. Fixes #38

### DIFF
--- a/rockstor-plugins/embyserver.json
+++ b/rockstor-plugins/embyserver.json
@@ -41,7 +41,8 @@
                         "index": 2
                     }
                 }
-            },
+            }
+        },
         "description": "Emby media server",
         "more_info": "<h4>Adding media to Emby.</h4><p>You can add Shares(with media) to Emby from the settings wizard of this Rock-on. Then, from Emby WebUI, you can update and re-index your library.</p>",
         "ui": {
@@ -52,3 +53,4 @@
         "version": "1.0"
     }
 }
+


### PR DESCRIPTION
Add a missing closing bracket in the json file that defines the EmbyServer Rockstor plugin (rock-ons).

Fixes #38 

Pull request ready for review.

After this patch the EmbyServer option shows up in Rockstor's Rock-ons screen and appears to present appropriate config options and then installs as expected. The resulting WebUI once launched via Rockstor's rock-ons button "EmbyServer UI" appears to work and presents a "Welcome to Emby!" message along with a quick start guide and next button.
