### PR TITLE
remove illegal groupdel -f from 02-user-onetime

### DIFF
--- a/docker-containers/beta/root/etc/cont-init.d/02-user-onetime
+++ b/docker-containers/beta/root/etc/cont-init.d/02-user-onetime
@@ -7,11 +7,11 @@ APP_GID=${APP_GID:-1000}
 APP_USER=${APP_USER:-appuser}
 
 # del emby user and group
-groupdel -f emby 2> /dev/null
 userdel -f emby 2> /dev/null
+groupdel emby 2> /dev/null
 
 if getent group ${APP_GID} > /dev/null; then
-  groupdel -f ${APP_GID} 2> /dev/null
+  groupdel ${APP_GID} 2> /dev/null
 fi
 
 # add USER GID

--- a/docker-containers/dev/root/etc/cont-init.d/02-user-onetime
+++ b/docker-containers/dev/root/etc/cont-init.d/02-user-onetime
@@ -7,11 +7,11 @@ APP_GID=${APP_GID:-1000}
 APP_USER=${APP_USER:-appuser}
 
 # del emby user and group
-groupdel -f emby 2> /dev/null
 userdel -f emby 2> /dev/null
+groupdel emby 2> /dev/null
 
 if getent group ${APP_GID} > /dev/null; then
-  groupdel -f ${APP_GID} 2> /dev/null
+  groupdel ${APP_GID} 2> /dev/null
 fi
 
 # add USER GID

--- a/docker-containers/stable/root/etc/cont-init.d/02-user-onetime
+++ b/docker-containers/stable/root/etc/cont-init.d/02-user-onetime
@@ -7,11 +7,11 @@ APP_GID=${APP_GID:-1000}
 APP_USER=${APP_USER:-appuser}
 
 # del emby user and group
-groupdel -f emby 2> /dev/null
 userdel -f emby 2> /dev/null
+groupdel emby 2> /dev/null
 
 if getent group ${APP_GID} > /dev/null; then
-  groupdel -f ${APP_GID} 2> /dev/null
+  groupdel ${APP_GID} 2> /dev/null
 fi
 
 # add USER GID


### PR DESCRIPTION
Fixes #51. groupdel has no `-f` option. Also, groupdel will not allow a
group to be deleted while any user still has it as its primary group, so
`userdel -f emby` is run first, then groupdel.
