### PR TITLE
Restart on failure instead of on abort

### DIFF
--- a/builders/emby-server/debfiles/emby-server.service
+++ b/builders/emby-server/debfiles/emby-server.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/emby-server start
-Restart=on-abort
+Restart=on-failure
 TimeoutSec=20
 ExecStopPost=/usr/bin/emby-server clear
 

--- a/docker-containers/base/overlay-common/var/cache/systemd/template@.service
+++ b/docker-containers/base/overlay-common/var/cache/systemd/template@.service
@@ -9,7 +9,7 @@ User=%i
 ExecStart=/usr/local/bin/emby-server service
 ExecStop=/usr/bin/docker stop -t 2 emby-server
 ExecStopPost=/usr/bin/docker rm -f emby-server
-Restart=on-abort
+Restart=on-failure
 TimeoutSec=20
 
 [Install]


### PR DESCRIPTION
When emby is crashing, it never get restarted because of the restart on-abort clause, a restart on-failure work better.