### PR TITLE
Update the logo URL to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Emby-Server
-![Alt text](http://i.imgur.com/MHQCm40.png "")
+![Alt text](https://i.imgur.com/MHQCm40.png "")
 - [Introduction](#introduction)
   - [Supported Tags](#supported-tags)
   - [Contributing](#contributing)


### PR DESCRIPTION
Hi guys, this is such a minor thing, but it fixes one annoying issue. The Readme is used as description on docker hub and because the logo loads over insecure connection, browsers show warning about insecure page.